### PR TITLE
Throttle to 62 FPS unless a new event is triggered, or user input posts

### DIFF
--- a/src/SKIF.cpp
+++ b/src/SKIF.cpp
@@ -3932,6 +3932,9 @@ wWinMain ( _In_     HINSTANCE hInstance,
         
         //OutputDebugString((L"[" + SKIF_Util_timeGetTimeAsWStr() + L"][#" + std::to_wstring(ImGui::GetFrameCount()) + L"][AWAKE] Woken up again!\n").c_str());
       }
+
+      else // Throttle to 62 FPS unless a new event is triggered, or user input is posted
+        MsgWaitForMultipleObjects (static_cast<DWORD>(vWatchHandles[SKIF_Tab_Selected].second.size()), vWatchHandles[SKIF_Tab_Selected].second.data(), false, 15, QS_ALLINPUT);
       
       if (bRefresh) //bRefresh)
       {


### PR DESCRIPTION
Prevents runaway drawing equal to display refresh rate. If there's an actual event that needs redrawing, or user input occurs, the throttle (wait timeout) is ignored and a new frame begins immediately.