### PR TITLE
Add shader parameter to allow linear SDR mode (FP16 SwapChain)

### DIFF
--- a/src/imgui/D3D11/imgui_impl_dx11.cpp
+++ b/src/imgui/D3D11/imgui_impl_dx11.cpp
@@ -630,6 +630,9 @@ ImGui_ImplDX11_RenderDrawData (ImDrawData *draw_data)
     {
       constant_buffer->luminance_scale [0] = 1.0f;
       constant_buffer->luminance_scale [1] = 2.2f;
+
+      // If you want linear gamma (FP16) in SDR, set this to 1.0f
+      constant_buffer->luminance_scale [3] = 1.0f;
     }
 
     else

--- a/src/imgui_pix_shader.hlsl
+++ b/src/imgui_pix_shader.hlsl
@@ -5,7 +5,7 @@ struct PS_INPUT
   float4 col : COLOR0;
   float2 uv  : TEXCOORD0;
   float2 uv2 : TEXCOORD1;
-  float3 uv3 : TEXCOORD2;
+  float4 uv3 : TEXCOORD2;
 };
 
 cbuffer viewportDims : register (b0)
@@ -168,7 +168,11 @@ float4 main (PS_INPUT input) : SV_Target
       out_col.rgba;
   }
 
+  bool linear_sdr =
+    input.uv3.w > 0;
+
   return
-    //( float4 (RemoveSRGBCurve (input.col.rgb), input.col.a) * float4 (RemoveSRGBCurve (out_col.rgb), out_col.a) ); // Used to allow 16 bpc format in SDR
-    ( input.col * out_col ); // Original method (results in grey washed out window on SDR 16 bpc)
+    linear_sdr ?
+      float4 (RemoveSRGBCurve (input.col.rgb), input.col.a) * float4 (RemoveSRGBCurve (out_col.rgb), out_col.a)
+               :                             ( input.col    *                                        out_col );
 };

--- a/src/imgui_vtx_shader.hlsl
+++ b/src/imgui_vtx_shader.hlsl
@@ -19,7 +19,7 @@ struct PS_INPUT
   float4 col : COLOR0;
   float2 uv  : TEXCOORD0;
   float2 uv2 : TEXCOORD1;
-  float3 uv3 : TEXCOORD2;
+  float4 uv3 : TEXCOORD2;
 };
 
 PS_INPUT main (VS_INPUT input)
@@ -33,7 +33,7 @@ PS_INPUT main (VS_INPUT input)
 
   output.col = input.col;
   output.uv2 = float2 (0.f, 0.f);
-  output.uv3 = Luminance.xyz;
+  output.uv3 = Luminance.xyzw;
 
   return output;
 }


### PR DESCRIPTION
Adjust line **635** of `imgui_impl_dx11.cpp` accordingly when you add an option for FP16 SDR.