### PR TITLE
Reduce VRAM requirements for font textures

### DIFF
--- a/resources/shaders/imgui_pix_shader.hlsl
+++ b/resources/shaders/imgui_pix_shader.hlsl
@@ -8,6 +8,11 @@ struct PS_INPUT
   float4 uv3 : TEXCOORD2; // constant_buffer->luminance_scale
 };
 
+cbuffer fontDims : register(b0)
+{
+  float4 font_dims;
+};
+
 sampler   sampler0    : register (s0);
 Texture2D texture0    : register (t0);
 
@@ -249,6 +254,14 @@ float4 main (PS_INPUT input) : SV_Target
 {
   float4 out_col  =
     texture0.Sample (sampler0, input.uv);
+
+  // Input is an alpha-only font texture if these are non-zero
+  if (font_dims.x + font_dims.y > 0.0f)
+  {
+    // Supply constant 1.0 for the color components, we only want alpha
+    out_col.rgb = 1.0f;
+  }
+
   float4 orig_col = out_col;
   
               // input.uv3.x        // Luminance (white point)


### PR DESCRIPTION
This cuts VRAM requirements down to 25% for font, by only storing an alpha channel and then reconstructing RGB in the UI's pixel shader.

It's not a massive savings, but I applied the same optimization to SK recently. Might as well do it here too...