### PR TITLE
Fix the check for controlled folder access

### DIFF
--- a/src/utility/utility.cpp
+++ b/src/utility/utility.cpp
@@ -2417,7 +2417,18 @@ SKIF_Util_GetControlledFolderAccess (void)
   if (ERROR_SUCCESS == RegOpenKeyExW (HKEY_LOCAL_MACHINE, LR"(SOFTWARE\Microsoft\Windows Defender\Windows Defender Exploit Guard\Controlled Folder Access\)", 0, KEY_READ | KEY_WOW64_64KEY, &hKey))
   {
     if (ERROR_SUCCESS == RegQueryValueEx (hKey, L"EnableControlledFolderAccess", NULL, NULL, (LPBYTE)&buffer, &size))
-      state = buffer;
+    {
+      // There are at least three possible states of controlled folder access,
+      // corresponding to these values:
+      //   0 - Disabled
+      //   1 - Enforcement mode
+      //   2 - Audit mode
+      //
+      // Only enforcement mode actually prevents writing to the controlled folders.
+      // SKIF shouldn't care if the user is using audit mode, so we'll treat audit mode
+      // as equivalent to controlled folder access being disabled.
+      state = (buffer == 1);
+    }
 
     PLOG_DEBUG << "Detected CFA as being " << ((state) ? "enabled" : "disabled");
 


### PR DESCRIPTION
The controlled folder access feature can be set to at least three
states: disabled; enforcement mode; and audit mode. Only enforcement
mode actually presents a problem for SKIF. However, SKIF currently
issues a warning implying that controlled folder access is causing
a problem for SKIF even if the feature is only in audit mode.

This patch changes the check for controlled folder access so that
it is perceived as being enabled only if it is set to enforcement
mode (not audit mode).