### PR TITLE
Added PCGW covers for Steam + GOG

### DIFF
--- a/include/stores/GOG/gog_library.h
+++ b/include/stores/GOG/gog_library.h
@@ -7,3 +7,4 @@ void SKIF_GOG_GetInstalledAppIDs       (std::vector <std::pair < std::string, ap
 void SKIF_GOG_UpdateGalaxyUserID       (void);
 bool SKIF_GOG_hasInstalledGamesChanged (void);
 bool SKIF_GOG_hasGalaxySettingsChanged (void);
+void SKIF_GOG_IdentifyAssetPCGW        (uint32_t app_id);

--- a/include/stores/Steam/steam_library.h
+++ b/include/stores/Steam/steam_library.h
@@ -267,3 +267,4 @@ DWORD                        SKIF_Steam_GetActiveProcess         (void);
 std::wstring                 SKIF_Steam_GetAppStateString        (HKEY* hKey, const wchar_t *wszStateKey);
 wchar_t                      SKIF_Steam_GetAppStateDWORD         (HKEY* hKey, const wchar_t *wszStateKey, DWORD *pdwStateVal);
 bool                         SKIF_Steam_UpdateAppState           (app_record_s *pApp);
+void                         SKIF_Steam_IdentifyAssetPCGW        (uint32_t app_id);

--- a/include/utility/registry.h
+++ b/include/utility/registry.h
@@ -351,6 +351,14 @@ struct SKIF_RegistrySettings {
     SKIF_MakeRegKeyB ( LR"(SOFTWARE\Kaldaien\Special K\)",
                          LR"(Fade Covers)" );
 
+  KeyValue <bool> regKVPCGWCoversGOG =
+    SKIF_MakeRegKeyB ( LR"(SOFTWARE\Kaldaien\Special K\)",
+                         LR"(PCGW Covers GOG)" );
+
+  KeyValue <bool> regKVPCGWCoversSteam =
+    SKIF_MakeRegKeyB ( LR"(SOFTWARE\Kaldaien\Special K\)",
+                         LR"(PCGW Covers Steam)" );
+
   KeyValue <int> regKVControllers =
     SKIF_MakeRegKeyI ( LR"(SOFTWARE\Kaldaien\Special K\Input\)",
                          LR"(EnableControllersInApps)" );
@@ -606,6 +614,8 @@ struct SKIF_RegistrySettings {
   bool bDeveloperMode           = false;
   bool bEfficiencyMode          =  true; // Should the main thread try to engage EcoQoS / Efficiency Mode on Windows 11 ?
   bool bFadeCovers              =  true;
+  bool bPCGWCoversGOG           =  true; // Should SKIF prefer covers from PCGW where available?
+  bool bPCGWCoversSteam         = false; // Should SKIF prefer covers from PCGW where available?
   bool bControllers             =  true; // Should SKIF support controller input ?
   bool bLoggingDeveloper        = false; // This is a log level "above" verbose logging that also includes stuff like window messages. Only useable for SKIF developers
   bool bPatreon                 =  true; // Should the Patreon button/kudos be shown when Special K is selected in the game list?

--- a/src/stores/Steam/steam_library.cpp
+++ b/src/stores/Steam/steam_library.cpp
@@ -32,6 +32,7 @@
 #include <filesystem>
 #include <regex>
 #include <utility/injection.h>
+#include <nlohmann/json.hpp>
 
 std::unique_ptr <skValveDataFile> appinfo = nullptr;
 
@@ -1501,4 +1502,80 @@ SKIF_Steam_UpdateAppState (app_record_s *pApp)
   }
 
   return true;
+}
+
+void
+SKIF_Steam_IdentifyAssetPCGW (uint32_t app_id)
+{
+  static SKIF_RegistrySettings& _registry   = SKIF_RegistrySettings::GetInstance ( );
+  static SKIF_CommonPathsCache& _path_cache = SKIF_CommonPathsCache::GetInstance ( );
+
+  std::wstring targetAssetPath = SK_FormatStringW(LR"(%ws\Assets\Steam\%i\)", _path_cache.specialk_userdata, app_id);
+
+  std::error_code ec;
+  // Create any missing directories
+  if (! std::filesystem::exists (            targetAssetPath, ec))
+        std::filesystem::create_directories (targetAssetPath, ec);
+
+  // Do not load a high-res copy if low-res covers are being used,
+  //   as in those scenarios we prefer to load the original Steam cover
+  if (! _registry._UseLowResCovers || _registry._UseLowResCoversHiDPIBypass)
+  {
+
+    // We intend to download PCGW's cover
+    // https://www.pcgamingwiki.com/w/api.php?action=cargoquery&format=json&tables=Infobox_game&fields=Cover_URL&where=Steam_AppID+HOLDS+'220'
+    // https://www.pcgamingwiki.com/w/api.php?action=cargoquery&format=json&tables=Infobox_game&fields=Cover_URL&where=Steam_AppID%20HOLDS%20%27220%27
+    std::wstring url  = L"https://www.pcgamingwiki.com/w/api.php?action=cargoquery&format=json&tables=Infobox_game&fields=Cover_URL&where=Steam_AppID+HOLDS+'";
+                  url += std::to_wstring (app_id);
+                  url += L"'";
+
+    // If PCGW cover has not been downloaded
+    if (! PathFileExistsW ((targetAssetPath + L"cover-pcgw.png").c_str()))
+    {
+      PLOG_DEBUG << "Downloading PCGW json: " << url;
+
+      SKIF_Util_GetWebResource (url, (targetAssetPath + L"pcgw.json"));
+
+      try
+      {
+        std::ifstream fileJson(targetAssetPath + L"pcgw.json");
+        nlohmann::json jf = nlohmann::json::parse(fileJson, nullptr, false);
+        fileJson.close();
+
+        if (jf.is_discarded ( ))
+        {
+          PLOG_ERROR << "Could not read PCGW JSON!";
+        }
+
+        else
+        {
+          if (jf["errors"].is_array())
+          {
+            PLOG_ERROR << "Could not read PCGW JSON!";
+          }
+
+          else
+          {
+            for (auto& image : jf["cargoquery"][0]["title"]["Cover URL"])
+            {
+              // Convert the URL value to a regular string
+              std::string assetUrl = image; // will throw exception if value does not exist
+
+              PLOG_DEBUG << "Downloading cover asset: " << assetUrl;
+
+              SKIF_Util_GetWebResource (SK_UTF8ToWideChar (assetUrl), targetAssetPath + L"cover-pcgw.png");
+            }
+          }
+        }
+      }
+      catch (const std::exception&)
+      {
+        PLOG_ERROR << "Error parsing PCGW JSON!";
+      }
+
+      // Delete the JSON file when we are done
+      if (_registry.iLogging < 5)
+        DeleteFile ((targetAssetPath + L"pcgw.json").c_str());
+    }
+  }
 }

--- a/src/tabs/library.cpp
+++ b/src/tabs/library.cpp
@@ -7245,10 +7245,17 @@ SKIF_UI_Tab_DrawLibrary (void)
                  d3 = false,
                  d4 = false;
 
+            // For GOG titles we may also store a PCGW cover that we must reset
+            if (! pApp->tex_cover.isCustom && pApp->store == app_record_s::Store::GOG)
+            {
+              fileName = L"cover-pcgw";
+              d3 = DeleteFile ((targetPath + fileName + L".png").c_str());
+            }
+
             // For Xbox titles we also store a fallback cover that we must reset
             if (! pApp->tex_cover.isCustom && pApp->store == app_record_s::Store::Xbox)
             {
-              fileName = L"cover-fallback.png";
+              fileName = L"cover-fallback";
               d3 = DeleteFile ((targetPath + fileName + L".png").c_str()),
               d4 = DeleteFile ((targetPath + fileName + L".jpg").c_str());
             }
@@ -7836,7 +7843,10 @@ SKIF_UI_Tab_DrawLibrary (void)
       // GOG
       else if (_pApp->store == app_record_s::Store::GOG)
       {
-        load_str = L"*_glx_vertical_cover.webp";
+        load_str = L"*_glx_vertical_cover.webp"; // Fallback
+
+        if (_registry.bPCGWCoversGOG)
+          SKIF_GOG_IdentifyAssetPCGW (_pApp->id);
       }
 
       // Epic
@@ -7876,6 +7886,9 @@ SKIF_UI_Tab_DrawLibrary (void)
         load_str    += LR"(/appcache/librarycache/)" +
           std::to_wstring (_pApp->id)                +
                                   L"/" + SK_FormatStringW (L"%hs", pApp->common_config.boxart_hash.c_str ());
+
+        if (_registry.bPCGWCoversSteam)
+          SKIF_Steam_IdentifyAssetPCGW (_pApp->id);
 
         // Do not load a high-res copy if low-res covers are being used,
         //   as in those scenarios we prefer to load the original 300x450 cover

--- a/src/tabs/settings.cpp
+++ b/src/tabs/settings.cpp
@@ -1209,6 +1209,38 @@ SKIF_UI_Tab_DrawSettings (void)
     if ( ImGui::Checkbox ( "Remember category collapsible state",       &_registry.bRememberCategoryState) )
       _registry.regKVRememberCategoryState.putData (                     _registry.bRememberCategoryState);
 
+    ImGui::Spacing         ( );
+
+    ImGui::TextColored (
+      ImGui::GetStyleColorVec4(ImGuiCol_SKIF_TextCaption),
+        "Prefer covers from PCGamingWiki for these platforms:"
+    );
+
+    ImGui::TreePush      ("PCGWCovers");
+
+    extern bool coverRefresh;
+    extern float fAlpha;
+
+    if (ImGui::Checkbox       ("GOG",         &_registry.bPCGWCoversGOG))
+    {
+      _registry.regKVPCGWCoversGOG.putData    (_registry.bPCGWCoversGOG);
+      coverRefresh = true;
+      fAlpha       = (_registry.bFadeCovers) ? 0.0f : 1.0f;
+    }
+
+    ImGui::SameLine ( );
+    ImGui::Spacing  ( );
+    ImGui::SameLine ( );
+
+    if (ImGui::Checkbox       ("Steam",       &_registry.bPCGWCoversSteam))
+    {
+      _registry.regKVPCGWCoversSteam.putData  (_registry.bPCGWCoversSteam);
+      coverRefresh = true;
+      fAlpha       = (_registry.bFadeCovers) ? 0.0f : 1.0f;
+    }
+
+    ImGui::TreePop          ( );
+
     if (enableColums)
     {
       ImGui::NextColumn    ( );
@@ -1276,6 +1308,8 @@ SKIF_UI_Tab_DrawSettings (void)
     ImGui::EndGroup ( );
 
     ImGui::TreePop          ( );
+
+    ImGui::Spacing         ( );
 
     ImGui::TextColored (ImGui::GetStyleColorVec4 (ImGuiCol_SKIF_Warning), ICON_FA_TRIANGLE_EXCLAMATION); // ImColor::HSV(0.11F, 1.F, 1.F)
     SKIF_ImGui_SetHoverTip ("Warning: This skips the regular platform launch process for the game,\n"

--- a/src/utility/registry.cpp
+++ b/src/utility/registry.cpp
@@ -495,6 +495,12 @@ SKIF_RegistrySettings::SKIF_RegistrySettings (void)
   if (regKVFadeCovers.hasData(&hKey))
     bFadeCovers            =   regKVFadeCovers             .getData (&hKey);
 
+  if (regKVPCGWCoversGOG.hasData(&hKey))
+    bPCGWCoversGOG         =   regKVPCGWCoversGOG          .getData (&hKey);
+
+  if (regKVPCGWCoversSteam.hasData(&hKey))
+    bPCGWCoversSteam       =   regKVPCGWCoversSteam        .getData (&hKey);
+
   bLoggingDeveloper        =   regKVLoggingDeveloper       .getData (&hKey);
 
   if (regKVPatreon.hasData(&hKey))


### PR DESCRIPTION
Adds support for downloading and using covers from PCGamingWiki. Defaults to **OFF** for Steam but **ON** for GOG. This is a way to work around GOG Galaxy's local low-res covers and prefer PCGW's cover (which typically are of a higher resolution) instead.

<img width="405" height="229" alt="image" src="https://github.com/user-attachments/assets/c2b32cdd-4b1a-45e2-a2be-74afa62ce833" />

Also fixes one minor UI bug, and a deletion bug with Xbox covers not being reset properly.