### PR TITLE
Monitor subfolders below the install_dir

### DIFF
--- a/src/tabs/library.cpp
+++ b/src/tabs/library.cpp
@@ -5782,7 +5782,7 @@ SKIF_UI_Tab_DrawLibrary (void)
         selection.dir_watch.reset ( );
 
       if (! pApp->install_dir.empty())
-        selection.dir_watch.isSignaled (pApp->install_dir);
+        selection.dir_watch.isSignaled (pApp->install_dir, UITab_None, TRUE);
     }
 
     int availableWorker = -1;


### PR DESCRIPTION
This fixes the local DLL file version not updating when the DLL file is located in a subfolder (UE4-5 games).

NOTE that I explicitly do not use `UITab_Library` (aka refresh SKIF when out-of-focus) due to the previous commit https://github.com/SpecialKO/SKIF/commit/fd3486f27d55ec4d84d789d9aa24fa30beb7cefe as doing so would cause constant refreshes of SKIF during game updates/installs.