### PR TITLE
Potential fix to empty tiny window on auto-updates

### DIFF
--- a/src/SKIF.cpp
+++ b/src/SKIF.cpp
@@ -2107,11 +2107,14 @@ wWinMain ( _In_     HINSTANCE hInstance,
     SKIF_vecRegularMode     = SKIF_vecRegularModeAdjusted * SKIF_ImGui_GlobalDPIScale;
 
     // Add support for an even smaller regular mode, at 800x675, but only if the regular size 1000x944 can't be used
-    if ((SKIF_vecRegularMode.x > monitor_extent.GetWidth () ||
-         SKIF_vecRegularMode.y > monitor_extent.GetHeight()))
+    if (monitor_extent.GetWidth() > 0)
     {
-      SKIF_vecRegularMode.x = 800.0f * SKIF_ImGui_GlobalDPIScale;
-      SKIF_vecRegularMode.y = 675.0f * SKIF_ImGui_GlobalDPIScale;
+      if ((SKIF_vecRegularMode.x > monitor_extent.GetWidth () ||
+           SKIF_vecRegularMode.y > monitor_extent.GetHeight()))
+      {
+        SKIF_vecRegularMode.x = 800.0f * SKIF_ImGui_GlobalDPIScale;
+        SKIF_vecRegularMode.y = 675.0f * SKIF_ImGui_GlobalDPIScale;
+      }
     }
 
     SKIF_vecServiceMode     = ImFloor (SKIF_vecServiceMode);

--- a/src/SKIF.cpp
+++ b/src/SKIF.cpp
@@ -2484,6 +2484,8 @@ wWinMain ( _In_     HINSTANCE hInstance,
             _registry.iUIPositionY != -1)
           ImGui::SetNextWindowPos (ImVec2 (static_cast<float> (_registry.iUIPositionX),
                                            static_cast<float> (_registry.iUIPositionY)));
+        else
+          RepositionSKIF = true;
       }
 
       // RepositionSKIF -- Step 2: Repositon the window

--- a/src/SKIF.cpp
+++ b/src/SKIF.cpp
@@ -3586,7 +3586,7 @@ wWinMain ( _In_     HINSTANCE hInstance,
       static std::string AutoUpdatePopupTitle;
       static bool        AutoUpdateChanges = (_updater.GetAutoUpdateNotes().max_length > 0 && ! _inject.SKVer32.empty() && _inject.SKVer32 == _registry.wsAutoUpdateVersion);
 
-      if (AutoUpdateChanges)
+      if (AutoUpdateChanges && SKIF_ImGui_IsFocused ())
       {
         AutoUpdateChanges = false;
         AutoUpdatePopup = PopupState_Open;


### PR DESCRIPTION
This is a potential fix to a hidden empty/glitched window that apparently can sometimes spawn on Windows boot in case SKIF detected and auto-installed an update.

No idea if this is the ultimate fix since I can't reproduce the issue myself, however this should hopefully take care of it as the change surpresses the `ImGui::OpenPopup ("###AutoUpdater")` call until the main window actually receives focus.

Screenshot of the bug in question (provided by colonel_gerdauf on Discord):

<img width="980" height="804" alt="image" src="https://github.com/user-attachments/assets/ce90276a-0e35-424a-8acb-514a3ff2b272" />
