### PR TITLE
Add Hardware: Vulkan Layer Management section

### DIFF
--- a/include/tabs/hardware.h
+++ b/include/tabs/hardware.h
@@ -1,4 +1,41 @@
 #pragma once
 
-void
-SKIF_UI_Tab_DrawHardware (void);
+void SKIF_UI_Tab_DrawHardware (void);
+
+// Vulkan layer stuff
+#include <string>
+#include <vector>
+#include <strsafe.h>
+
+enum VkLayerType {
+  VkLayerType_Implicit,
+  VkLayerType_Explicit,
+  VkLayerType_Unknown
+};
+
+struct VkLayer {
+  struct reg {
+    std::wstring    Key         = L"";
+    std::wstring    Value       = L"";
+    DWORD           Data        =   0; // 0 = enabled; >0 = disabled
+    bool            WOW6432Node = false;
+  };
+    
+  std:: string      Name;
+  std::wstring      Pattern   = L"";
+  std::vector <reg> Matches   = { };
+  bool              isEnabled = false; // Simplified state
+  bool              isIncompatible = false; // Is the layer flagged as having known compatibility issues?
+  VkLayerType       Type      = VkLayerType_Unknown;
+
+  std:: string      uiWarnLabel; // Label used on the Monitor tab
+  std:: string      uiHoverTxt;  // Status bar text
+  std:: string      uiHoverTip;  // Tooltip text
+  std::wstring      regCmd;      // Combined command to toggle
+
+  void Toggle (void);
+};
+
+extern std::pair<bool, std::vector<VkLayer>> g_VkLayers;
+
+void SKIF_Hardware_RefreshVulkanLayers (void);

--- a/include/utility/utility.h
+++ b/include/utility/utility.h
@@ -299,7 +299,7 @@ struct SKIF_RegistryWatch {
     BOOL         wow64_64key; // Access a 64-bit key from either a 32-bit or 64-bit application.
   } _init;
 
-  HKEY    _hKeyBase    = { };
+  HKEY    _hKeyBase    = NULL;
   HANDLE  _hEvent      = NULL; // If the CreateEvent function fails, the return value is NULL.
   UITab   _waitTab     = UITab_None;
 };

--- a/src/tabs/common_ui.cpp
+++ b/src/tabs/common_ui.cpp
@@ -19,6 +19,8 @@
 #include <ShlObj.h>
 #include <fonts/fa_621b.h>
 
+#include <tabs/hardware.h>
+
 void SKIF_UI_DrawComponentVersion (void)
 {
   static SKIF_InjectionContext& _inject   = SKIF_InjectionContext::GetInstance ( );
@@ -111,6 +113,8 @@ void SKIF_UI_DrawPlatformStatus (void)
   static SKIF_GamePadInputHelper& _gamepad  = SKIF_GamePadInputHelper::GetInstance ( );
   static SKIF_RegistrySettings&   _registry = SKIF_RegistrySettings  ::GetInstance ( );
 
+  SKIF_Hardware_RefreshVulkanLayers ( );
+
   ImGui::BeginGroup       ( );
   ImGui::Spacing          ( );
   ImGui::SameLine         ( );
@@ -164,45 +168,6 @@ void SKIF_UI_DrawPlatformStatus (void)
     {"RTSS",                L"RTSS.exe"}
   };
 
-  struct VulkanLayer {
-    struct reg {
-      std::wstring    Key      = L"";
-      std::wstring    Value    = L"";
-      DWORD           Data     =   0; // 0 = enabled; >0 = disabled
-    };
-    
-    std:: string      Name;
-    std::wstring      Pattern   = L"";
-    std::vector <reg> Matches   = { };
-    bool              isEnabled = false; // Simplified state
-
-    std:: string      uiLabel;
-    std:: string      uiHoverTxt; // Status bar text
-    std::wstring      regCmd;     // Combined command to toggle
-
-    VulkanLayer (std::string n, std::wstring pn)
-    {
-      Name    = n;
-      Pattern = pn;
-    }
-  };
-
-  // Unwinder on the topic of Vulkan layer compatibility issues:
-  // Ironically, true reason of 99% of compatibility issues with third-party implicit layers are on LunarG.
-  // Their sample Vulkan layer code, which virtually everyone used as a template to create own layers,
-  //   had a bug with Vulkan instance handle leak. So it was and it is echoed in any layer based on that
-  //     source code. I nailed it down myself in my layer when debugging compatibility issues with DXVK.
-  // 
-  // Version 7.3.0 (published on 28.02.2021)
-  // - Fixed Vulkan device and instance handle leak in Vulkan bootstrap layer
-
-  static VulkanLayer Layers[]   = {
-  //{ "RTSS",             LR"(RTSSVkLayer)"               }, // Disabled since we seems to have no confirmed compatibility issues for now. // Aemony, 2024-02-02
-    { "ReShade",          LR"(ReShade)"                   }, //
-    { "OBS Studio",       LR"(obs-vulkan)"                }, //
-    { "Mirillis Action!", LR"(MirillisActionVulkanLayer)" }  // Causes Borderlands 2 with DXVK to fail to launch. // Aemony, 2024-02-02
-  };
-
   // Timer has expired, refresh
   if (dwLastRefresh < SKIF_Util_timeGetTime() && (! ImGui::IsAnyMouseDown ( ) || ! SKIF_ImGui_IsFocused ( ) ))
   {
@@ -210,14 +175,6 @@ void SKIF_UI_DrawPlatformStatus (void)
     {
       p.ProcessID = 0;
       p.isRunning = false;
-    }
-
-    for (auto& l : Layers)
-    {
-      l.Matches.clear();
-      l.isEnabled  = false;
-      l.uiLabel    =  "";
-      l.uiHoverTxt =  "";
     }
 
     PROCESSENTRY32W pe32 = { };
@@ -253,118 +210,6 @@ void SKIF_UI_DrawPlatformStatus (void)
             }
           }
         } while (Process32NextW (hProcessSnap, &pe32));
-      }
-    }
-
-    static const HKEY regHives[] = {
-      HKEY_LOCAL_MACHINE,
-      HKEY_CURRENT_USER,
-    };
-
-    // Do not bother checking explicit layers
-    static const std::wstring regKeys[] = {
-      LR"(SOFTWARE\Khronos\Vulkan\ImplicitLayers)"
-    //LR"(SOFTWARE\Khronos\Vulkan\ExplicitLayers)"
-#ifdef _WIN64
-     ,LR"(SOFTWARE\WOW6432Node\Khronos\Vulkan\ImplicitLayers)"
-    //LR"(SOFTWARE\WOW6432Node\Khronos\Vulkan\ExplicitLayers)"
-#endif
-    };
-
-    // Identify conflicting Vulkan layers through the registry
-    for (auto& hHive : regHives)
-    {
-      for (auto& wzKey : regKeys)
-      {
-        HKEY hKey;
-
-        if (RegOpenKeyExW (hHive, wzKey.c_str(), 0, KEY_READ, &hKey) == ERROR_SUCCESS) // Worth using KEY_WOW64_64KEY ?
-        {
-          DWORD dwIndex           = 0, // A variable that receives the number of values that are associated with the key.
-                dwResult          = 0,
-                dwMaxValueNameLen = 0, // A pointer to a variable that receives the size of the key's longest value name, in Unicode characters. The size does not include the terminating null character.
-                dwMaxValueLen     = 0; // A pointer to a variable that receives the size of the longest data component among the key's values, in bytes.
-
-          if (RegQueryInfoKeyW (hKey, NULL, NULL, NULL, NULL, NULL, NULL, &dwIndex, &dwMaxValueNameLen, &dwMaxValueLen, NULL, NULL) == ERROR_SUCCESS)
-          {
-            while (dwIndex > 0)
-            {
-              dwIndex--;
-          
-              DWORD dwValueNameLen =
-                    (dwMaxValueNameLen + 2);
-
-              std::unique_ptr <wchar_t []> pValue =
-                std::make_unique <wchar_t []> (sizeof (wchar_t) * dwValueNameLen);
-          
-              DWORD dwValueLen =
-                    (dwMaxValueLen);
-
-              LPBYTE pData = (LPBYTE)malloc(dwValueLen);
-              memcpy(pData, &dwValueLen, sizeof(DWORD));
-
-              DWORD dwType = REG_NONE;
-
-              dwResult = RegEnumValueW (hKey, dwIndex, (wchar_t *) pValue.get(), &dwValueNameLen, NULL, &dwType, pData, &dwValueLen);
-
-              if (dwResult == ERROR_NO_MORE_ITEMS)
-                break;
-
-              if (dwResult == ERROR_SUCCESS && dwType == REG_DWORD)
-              {
-                for (auto& l : Layers)
-                {
-                  if (StrStrIW (pValue.get(), l.Pattern.c_str()) != NULL)
-                  {
-                    VulkanLayer::reg item;
-
-                    item.Key       = ((hHive == HKEY_LOCAL_MACHINE) ? LR"(HKLM\)" : LR"(HKCU\)") + wzKey;
-                    item.Value     = pValue.get();
-                    item.Data      = *((DWORD*)pData);
-
-                    if (item.Data == 0)
-                      l.isEnabled = true;
-
-                    l.Matches.push_back (item);
-                  }
-                }
-              }
-
-              free(pData);
-            }
-          }
-
-          RegCloseKey (hKey);
-        }
-      }
-    }
-
-    // Prep the UI / command components
-    for (auto& l : Layers)
-    {
-      if (l.Matches.empty())
-        continue;
-
-      l.regCmd     = LR"(/c )";
-      l.uiLabel    = (l.isEnabled) ? (l.Name + " may conflict with Special K!") : (l.Name + " has been disabled.");
-      l.uiHoverTxt = "";
-
-      for (auto& item : l.Matches)
-      {
-        if (!item.Value.empty())
-        {
-          l.regCmd += SK_FormatStringW (LR"(%ws add "%ws" /v "%ws" /t REG_DWORD /d %i /f)",
-              ((l.regCmd.length() <= 3) ? L"reg" : L"& reg"),
-                item.Key.c_str(),
-                item.Value.c_str(),
-              ((l.isEnabled) ? 1 : 0)
-          );
-
-          if (l.uiHoverTxt.empty())
-            l.uiHoverTxt  =         SK_WideCharToUTF8 (item.Key);
-          else
-            l.uiHoverTxt += " / " + SK_WideCharToUTF8 (item.Key);
-        }
       }
     }
 
@@ -433,50 +278,49 @@ void SKIF_UI_DrawPlatformStatus (void)
 #endif
   }
 
-  bool header = false;
-  for (auto& l : Layers)
+  if (g_VkLayers.first)
   {
-    if (l.Matches.empty())
-      continue;
+    SKIF_ImGui_Spacing      ( );
 
-    if (! header)
+    ImGui::TextColored (
+      ImGui::GetStyleColorVec4(ImGuiCol_SKIF_TextCaption),
+        "Problematic Vulkan layers:"
+    );
+
+    ImGui::SameLine         ( );
+
+    ImGui::TextColored (
+      ImGui::GetStyleColorVec4(ImGuiCol_SKIF_Info),
+        ICON_FA_LIGHTBULB
+    );
+
+    SKIF_ImGui_SetHoverTip ("The Vulkan layers listed below have known compatibility issues with Special K and may cause issues.\n"
+                            "Click on the layers to toggle them on/off. Note however that this will affects all apps/games.");
+
+    SKIF_ImGui_Spacing      ( );
+
+    for (auto& l : g_VkLayers.second)
     {
-      header = true;
+      if (! l.isIncompatible)
+        continue;
 
-      SKIF_ImGui_Spacing      ( );
+      if (l.Matches.empty())
+        continue;
 
-      ImGui::TextColored (
-        ImGui::GetStyleColorVec4(ImGuiCol_SKIF_TextCaption),
-          "Vulkan layers:"
-      );
+      ImGui::SetCursorPosX (ImGui::GetCursorPosX() + ImGui::GetStyle().FramePadding.x);
 
-      ImGui::SameLine         ( );
+      bool dontCare = l.isEnabled;
+      ImGui::PushStyleColor   (ImGuiCol_Text, ImGui::GetStyleColorVec4 ((l.isEnabled) ? ImGuiCol_SKIF_Yellow : ImGuiCol_SKIF_Success));
+      ImGui::BeginGroup       ( );
+      if (ImGui::Checkbox     (l.uiWarnLabel.c_str(), &dontCare))
+        l.Toggle ( );
 
-      ImGui::TextColored (
-        ImGui::GetStyleColorVec4(ImGuiCol_SKIF_Info),
-          ICON_FA_LIGHTBULB
-      );
+      ImGui::EndGroup         ( );
+      ImGui::PopStyleColor    ( );
 
-      SKIF_ImGui_SetHoverTip ("Vulkan allows applications to install custom layers that are auto-loaded by all games/apps.\n"
-                              "Those that have known compatibility issues with Special K can be toggled on/off from here.");
-
-      SKIF_ImGui_Spacing      ( );
+      SKIF_ImGui_SetHoverText (l.uiHoverTxt);
+      SKIF_ImGui_SetHoverTip  ((l.isEnabled) ? "This layer is enabled and may cause issues. Click to disable it." : "This layer is disabled. Click to re-enable it.");
     }
-
-    ImGui::PushStyleColor   (ImGuiCol_Text, ImGui::GetStyleColorVec4 ((l.isEnabled) ? ImGuiCol_SKIF_Yellow : ImGuiCol_SKIF_Success));
-
-    ImGui::Spacing          ( );
-    ImGui::SameLine         ( );
-    ImGui::BeginGroup       ( );
-    ImGui::Text             ((l.isEnabled) ? ICON_FA_TRIANGLE_EXCLAMATION " " : ICON_FA_CHECK " ");
-    ImGui::SameLine         ( );
-    if (ImGui::Selectable   (l.uiLabel.c_str()))
-      ShellExecuteW (nullptr, L"runas", L"cmd", l.regCmd.c_str(), nullptr, SW_SHOWNORMAL);
-    ImGui::EndGroup         ( );
-    ImGui::PopStyleColor    ( );
-
-    SKIF_ImGui_SetHoverText (l.uiHoverTxt);
-    SKIF_ImGui_SetHoverTip  ("Click to toggle this Vulkan layer.");
   }
 
   SKIF_ImGui_Spacing      ( );
@@ -487,7 +331,7 @@ void SKIF_UI_DrawPlatformStatus (void)
   if (! _registry.bControllers)
   {
     ImGui::TextDisabled     ("Disabled");
-    SKIF_ImGui_SetHoverTip  ("Please re-enable controller support in the Settings tab.");
+    SKIF_ImGui_SetHoverTip  ("Controller support can be re-enabled in the Settings tab.");
   }
 
   else

--- a/src/tabs/hardware.cpp
+++ b/src/tabs/hardware.cpp
@@ -471,7 +471,7 @@ SKIF_Hardware_RefreshVulkanLayers (void)
     { "Mirillis Action!",     LR"(MirillisActionVulkanLayer)", true  },
     { "OBS Studio",           LR"(obs-vulkan)"               , true  },
     { "ReShade",              LR"(ReShade)"                  , true  },
-    { "RTSS",                 LR"(RTSSVkLayer)"              , true  }, // The RTSS layer does not seem to do anything when the app is not running, and we cover that elsewhere.
+    { "RTSS",                 LR"(RTSSVkLayer)"              , false }, // The RTSS layer does not seem to do anything when the app is not running, and we cover that elsewhere.
     { "Steam Fossilize",      LR"(SteamFossilizeVulkanLayer)", false },
     { "Steam Overlay",        LR"(SteamOverlayVulkanLayer)"  , false },
   };

--- a/src/tabs/hardware.cpp
+++ b/src/tabs/hardware.cpp
@@ -1,4 +1,6 @@
 
+#include <tabs/hardware.h>
+
 #include <utility/skif_imgui.h>
 #include <fonts/fa_621.h>
 #include <fonts/fa_621b.h>
@@ -13,6 +15,37 @@
 
 #include <utility/fsutil.h>
 #include <utility/registry.h>
+
+// Global Vulkan layer object (incompatible, layers)
+std::pair<bool, std::vector<VkLayer>> g_VkLayers = { false, { } };
+
+void
+VkLayer::Toggle (void)
+{
+  SHELLEXECUTEINFOW
+    sexi              = { };
+    sexi.cbSize       = sizeof (SHELLEXECUTEINFOW);
+    sexi.lpVerb       = L"runas";
+    sexi.lpFile       = L"cmd";
+    sexi.lpParameters = regCmd.c_str();
+    sexi.lpDirectory  = nullptr;
+    sexi.nShow        = SW_SHOWNORMAL;
+    sexi.fMask        = SEE_MASK_NOCLOSEPROCESS | // We need the PID of the process that gets started
+                        SEE_MASK_NOASYNC        | // Never async since our own process needs to wait until the new process is done
+                        SEE_MASK_NOZONECHECKS;    // No zone check needs to be performed
+
+  ShellExecuteExW (&sexi);
+
+  // Wait for the process to finish before continuing
+  if (sexi.hInstApp  > (HINSTANCE)32 &&
+      sexi.hProcess != NULL)
+  {
+    WaitForSingleObject (sexi.hProcess, INFINITE);
+    CloseHandle (sexi.hProcess);
+    isEnabled = ! isEnabled;
+  }
+}
+
 
 struct Monitor_MPO_Support
 {
@@ -416,6 +449,207 @@ GetDrvInstallState (DrvInstallState& ptrStatus, std::wstring svcName = L"SK_WinR
   return binaryPath;
 };
 
+// Unwinder on the topic of Vulkan layer compatibility issues:
+// Ironically, true reason of 99% of compatibility issues with third-party implicit layers are on LunarG.
+// Their sample Vulkan layer code, which virtually everyone used as a template to create own layers,
+//   had a bug with Vulkan instance handle leak. So it was and it is echoed in any layer based on that
+//     source code. I nailed it down myself in my layer when debugging compatibility issues with DXVK.
+// 
+// Version 7.3.0 (published on 28.02.2021)
+// - Fixed Vulkan device and instance handle leak in Vulkan bootstrap layer
+
+void
+SKIF_Hardware_RefreshVulkanLayers (void)
+{
+  static SKIF_RegistrySettings&   _registry = SKIF_RegistrySettings  ::GetInstance ( );
+
+  //   humanFriendlyName,         valuePattern,                knownCompatibilityIssue
+  static const std::tuple<std::string, std::wstring, bool> VkLayerKnownDatabase[] = {
+    { "Epic Online Services", LR"(EOSOverlayVkLayer)"        , false },
+    { "FPS Monitor",          LR"(fpsmonvk)"                 , false },
+    { "GOG Galaxy",           LR"(galaxy_overlay_vklayer)"   , false },
+    { "Mirillis Action!",     LR"(MirillisActionVulkanLayer)", true  },
+    { "OBS Studio",           LR"(obs-vulkan)"               , true  },
+    { "ReShade",              LR"(ReShade)"                  , true  },
+    { "RTSS",                 LR"(RTSSVkLayer)"              , true  }, // The RTSS layer does not seem to do anything when the app is not running, and we cover that elsewhere.
+    { "Steam Fossilize",      LR"(SteamFossilizeVulkanLayer)", false },
+    { "Steam Overlay",        LR"(SteamOverlayVulkanLayer)"  , false },
+  };
+
+  static SKIF_RegistryWatch watchers[] = {
+    { HKEY_LOCAL_MACHINE, LR"(SOFTWARE\Khronos\Vulkan)", L"SKIF_HKLM_Vulkan",   TRUE, REG_NOTIFY_CHANGE_LAST_SET, UITab_None, false }
+   ,{ HKEY_CURRENT_USER,  LR"(SOFTWARE\Khronos\Vulkan)", L"SKIF_HKCU_Vulkan",   TRUE, REG_NOTIFY_CHANGE_LAST_SET, UITab_None, false }
+#ifdef _WIN64
+   ,{ HKEY_LOCAL_MACHINE, LR"(SOFTWARE\Khronos\Vulkan)", L"SKIF_HKLM32_Vulkan", TRUE, REG_NOTIFY_CHANGE_LAST_SET, UITab_None, true  }
+   ,{ HKEY_CURRENT_USER,  LR"(SOFTWARE\Khronos\Vulkan)", L"SKIF_HKCU32_Vulkan", TRUE, REG_NOTIFY_CHANGE_LAST_SET, UITab_None, true  }
+#endif
+  };
+
+  static bool update = true; // First run
+
+  // Check if any changes have been made to the registry
+  for (auto& watcher : watchers)
+    if (watcher.isSignaled())
+      update = true;
+
+  if (update)
+  {
+    update = false;
+    g_VkLayers.first = false;
+
+    for (auto& l : g_VkLayers.second)
+    {
+      l.isEnabled = false;
+      l.Matches.clear();
+    }
+
+    static const HKEY regHives[] = {
+      HKEY_LOCAL_MACHINE,
+      HKEY_CURRENT_USER,
+    };
+
+    // It is questionable if we even need to check explicit layers...
+    static const std::pair<VkLayerType, std::wstring> regKeys[] = {
+      { VkLayerType_Implicit, LR"(ImplicitLayers)" }
+     ,{ VkLayerType_Explicit, LR"(ExplicitLayers)" }
+    };
+
+    // Detect Vulkan layers through the registry
+    for (auto& watcher : watchers)
+    {
+      for (auto& pKey : regKeys)
+      {
+        HKEY hKey;
+
+        if (RegOpenKeyExW (watcher._hKeyBase, pKey.second.c_str(), 0, KEY_READ, &hKey) == ERROR_SUCCESS) // Worth using KEY_WOW64_64KEY ?
+        {
+          DWORD dwIndex           = 0, // A variable that receives the number of values that are associated with the key.
+                dwResult          = 0,
+                dwMaxValueNameLen = 0, // A pointer to a variable that receives the size of the key's longest value name, in Unicode characters. The size does not include the terminating null character.
+                dwMaxValueLen     = 0; // A pointer to a variable that receives the size of the longest data component among the key's values, in bytes.
+
+          if (RegQueryInfoKeyW (hKey, NULL, NULL, NULL, NULL, NULL, NULL, &dwIndex, &dwMaxValueNameLen, &dwMaxValueLen, NULL, NULL) == ERROR_SUCCESS)
+          {
+            while (dwIndex > 0)
+            {
+              dwIndex--;
+          
+              DWORD dwValueNameLen =
+                    (dwMaxValueNameLen + 2);
+
+              std::unique_ptr <wchar_t []> pValue =
+                std::make_unique <wchar_t []> (sizeof (wchar_t) * dwValueNameLen);
+          
+              DWORD dwValueLen =
+                    (dwMaxValueLen);
+
+              LPBYTE pData = (LPBYTE)malloc(dwValueLen);
+              memcpy(pData, &dwValueLen, sizeof(DWORD));
+
+              DWORD dwType = REG_NONE;
+
+              dwResult = RegEnumValueW (hKey, dwIndex, (wchar_t *) pValue.get(), &dwValueNameLen, NULL, &dwType, pData, &dwValueLen);
+
+              if (dwResult == ERROR_NO_MORE_ITEMS)
+                break;
+
+              if (dwResult == ERROR_SUCCESS && dwType == REG_DWORD)
+              {
+                VkLayer* ptr = nullptr;
+
+                // Do we already have one of the same type (implicit/explicit) ?
+                for (auto& l : g_VkLayers.second)
+                {
+                  if (l.Type == pKey.first && StrStrIW (pValue.get(), l.Pattern.c_str()) != NULL)
+                  {
+                    ptr = &l;
+                  }
+                }
+
+                // Create a new entry if we do not
+                if (ptr == nullptr)
+                {
+                  VkLayer new_layer = {
+                    .Name = SK_WideCharToUTF8 (pValue.get()),
+                    .Type = pKey.first
+                  };
+
+                  for (auto& knownLayer : VkLayerKnownDatabase)
+                  {
+                    if (StrStrIW (pValue.get(), std::get<std::wstring>(knownLayer).c_str()) != NULL)
+                    {
+                      new_layer.Name           = std::get<std::string>(knownLayer);
+                      new_layer.Pattern        = std::get<std::wstring>(knownLayer);
+                      new_layer.isIncompatible = std::get<bool>(knownLayer);
+                    }
+                  }
+
+                  g_VkLayers.second.push_back (std::move(new_layer));
+                  ptr = &g_VkLayers.second.back();
+                }
+
+                VkLayer::reg item;
+
+                item.Key   = ((watcher._init.root == HKEY_LOCAL_MACHINE) ? LR"(HKLM\)" : LR"(HKCU\)") + watcher._init.sub_key + LR"(\)" + pKey.second;
+                item.Value = pValue.get();
+                item.Data  = *((DWORD*)pData);
+                item.WOW6432Node = (watcher._init.wow64_32key == TRUE);
+
+                if (ptr->isIncompatible)
+                  g_VkLayers.first = true;
+
+                ptr->Matches.push_back (std::move(item));
+              }
+
+              free(pData);
+            }
+          }
+
+          RegCloseKey (hKey);
+        }
+      }
+    }
+
+    // Prep the UI / command components
+    for (auto& l : g_VkLayers.second)
+    {
+      if (l.Matches.empty())
+        continue;
+
+      for (auto& item : l.Matches)
+        if (! item.Value.empty() && item.Data == 0)
+          l.isEnabled = true;
+
+      l.regCmd      = LR"(/c )";
+      l.uiWarnLabel = (" " + l.Name + ((l.isEnabled) ? "  " ICON_FA_TRIANGLE_EXCLAMATION : ""));
+      l.uiHoverTip  = "";
+      l.uiHoverTxt  = "";
+
+      for (auto& item : l.Matches)
+      {
+        if (! item.Value.empty())
+        {
+          l.regCmd += SK_FormatStringW (LR"(%ws add "%ws" /v "%ws" /t REG_DWORD /d %i /f %ws)",
+              ((l.regCmd.length() <= 3) ? L"reg" : L" & reg"),
+                item.Key.c_str(),
+                item.Value.c_str(),
+              ((l.isEnabled) ? 1 : 0),
+              ((item.WOW6432Node) ? LR"(/reg:32)" : LR"(/reg:64)")
+          );
+
+          if (l.uiHoverTip.empty())
+            l.uiHoverTip  =         SK_WideCharToUTF8 (item.Value);
+          else
+            l.uiHoverTip += "\n"  + SK_WideCharToUTF8 (item.Value);
+
+          if (l.uiHoverTxt.empty())
+            l.uiHoverTxt = SK_FormatString (R"(cmd /c reg add "%s"...)", SK_WideCharToUTF8 (item.Key).c_str());
+        }
+      }
+    }
+  }
+}
+
 void
 SKIF_UI_Tab_DrawHardware (void)
 {
@@ -471,6 +705,8 @@ SKIF_UI_Tab_DrawHardware (void)
     if (valvePlug && _registry.regKVValvePlug.hasData())
       _registry.iValvePlug = _registry.regKVValvePlug.getData();
   }
+
+  SKIF_Hardware_RefreshVulkanLayers ( );
 
   SKIF_Tab_Selected = UITab_Hardware;
   if (SKIF_Tab_ChangeTo == UITab_Hardware)
@@ -1230,6 +1466,114 @@ SKIF_UI_Tab_DrawHardware (void)
   ImGui::Spacing ();
   ImGui::Spacing ();
 #endif
+#pragma endregion
+
+#pragma region Section: Vulkan Layer Management
+  if (ImGui::CollapsingHeader ("Vulkan Layer Management###SKIF_HardwareHeader-3"))
+  {
+    ImGui::PushStyleColor (
+      ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_SKIF_TextBase)
+                            );
+
+    SKIF_ImGui_Spacing      ( );
+
+    ImGui::BeginGroup  ();
+
+    ImGui::TextWrapped    (
+      "The Vulkan API includes support for defining third-party layers that can be implicitly or explicitly loaded by applications."
+      " These third-party layers has been known to cause compatibility issues with other third-party injectors and tools such as Special K,"
+      " and might therefor be of interest to disable. Note that any change made below will affect all apps/games on the system!"
+    );
+
+    SKIF_ImGui_Spacing ( );
+
+    ImGui::Spacing     ();
+    ImGui::SameLine    ();
+    ImGui::TextColored (ImGui::GetStyleColorVec4(ImGuiCol_SKIF_Info), (const char *)u8"\u2022 ");
+    ImGui::SameLine    ();
+    ImGui::TextWrapped ("Implicit layers are automatically enabled in any running games/apps.");
+
+    ImGui::Spacing     ();
+    ImGui::SameLine    ();
+    ImGui::TextColored (ImGui::GetStyleColorVec4(ImGuiCol_SKIF_Info), (const char *)u8"\u2022 ");
+    ImGui::SameLine    ();
+    ImGui::TextWrapped ("Explicit layers are only enabled if the game/app requires it.");
+
+    static const std::tuple<VkLayerType, std::string, std::string> types[] = {
+      { VkLayerType_Implicit, "Implicit Vulkan Layers", "Implicit layers are automatically enabled in any running games/apps." },
+      { VkLayerType_Explicit, "Explicit Vulkan Layers", "Explicit layers are only enabled if the game/app requires it."        }
+    };
+
+    for (auto& type : types)
+    {
+      SKIF_ImGui_Spacing ( );
+
+      ImGui::TextColored (
+        ImGui::GetStyleColorVec4(ImGuiCol_SKIF_TextCaption),
+          std::get<1>(type).c_str()
+      );
+
+      ImGui::SameLine    ( );
+
+      ImGui::TextColored (
+        ImGui::GetStyleColorVec4(ImGuiCol_SKIF_Info),
+          ICON_FA_LIGHTBULB
+      );
+
+      SKIF_ImGui_SetHoverTip (std::get<2>(type).c_str());
+
+      SKIF_ImGui_Spacing ( );
+
+      bool foundAny = false;
+
+      for (auto& l : g_VkLayers.second)
+      {
+        if (l.Type != std::get<VkLayerType>(type))
+          continue;
+
+        if (l.Matches.empty())
+          continue;
+
+        foundAny = true;
+
+        ImVec2 posXY = ImGui::GetCursorPos ();
+
+        if (l.isIncompatible && l.isEnabled)
+        {
+          ImGui::SetCursorPosY (posXY.y + ImGui::GetStyle().FramePadding.y);
+          ImGui::TextColored   (ImGui::GetStyleColorVec4 (ImGuiCol_SKIF_Yellow), ICON_FA_TRIANGLE_EXCLAMATION);
+
+          SKIF_ImGui_SetHoverTip ("This layer has known compatibility issues with Special K and may cause issues.");
+
+          ImGui::SameLine ( );
+          ImGui::SetCursorPos (posXY);
+        }
+
+        ImGui::TreePush("");
+        bool dontCare = l.isEnabled;
+        if (ImGui::Checkbox     (l.Name.c_str(), &dontCare))
+          l.Toggle ( );
+        ImGui::TreePop();
+
+        SKIF_ImGui_SetHoverText (l.uiHoverTxt);
+        SKIF_ImGui_SetHoverTip  (l.uiHoverTip);
+      }
+
+      if (! foundAny)
+      {
+        ImGui::TreePush("");
+        ImGui::Text             ("No layer of this kind was found.");
+        ImGui::TreePop();
+      }
+    }
+
+    ImGui::EndGroup ();
+
+    ImGui::PopStyleColor ();
+  }
+
+  ImGui::Spacing ();
+  ImGui::Spacing ();
 #pragma endregion
 
 }

--- a/src/utility/utility.cpp
+++ b/src/utility/utility.cpp
@@ -3901,9 +3901,6 @@ SKIF_RegistryWatch::SKIF_RegistryWatch ( HKEY hRootKey, const wchar_t* wszSubKey
 
   reset ();
 
-  if (_waitTab != UITab_None && _hEvent != NULL)
-    vWatchHandles[_waitTab].push_back(_hEvent);
-
   if (_hEvent != NULL)
   {
     if (_waitTab == UITab_ALL)
@@ -3930,11 +3927,12 @@ SKIF_RegistryWatch::~SKIF_RegistryWatch (void)
     }
     else if (_waitTab != UITab_None && ! vWatchHandles[_waitTab].empty())
       vWatchHandles[_waitTab].erase(std::remove(vWatchHandles[_waitTab].begin(), vWatchHandles[_waitTab].end(), _hEvent), vWatchHandles[_waitTab].end());
-  }
 
-  RegCloseKey (_hKeyBase);
-  CloseHandle (_hEvent);
-  _hEvent = NULL;
+    RegCloseKey (_hKeyBase);
+    _hKeyBase = NULL;
+    CloseHandle (_hEvent);
+    _hEvent = NULL;
+  }
 }
 
 LSTATUS
@@ -3946,9 +3944,13 @@ SKIF_RegistryWatch::registerNotify (void)
 void
 SKIF_RegistryWatch::reset (void)
 {
-  RegCloseKey (_hKeyBase);
+  if (_hKeyBase != NULL)
+  {
+    RegCloseKey (_hKeyBase);
+    _hKeyBase = NULL;
+  }
 
-  if ((intptr_t)_hEvent > 0)
+  if (_hEvent != NULL)
     ResetEvent (_hEvent);
 
   LSTATUS lStat =
@@ -3961,10 +3963,29 @@ SKIF_RegistryWatch::reset (void)
 
   if (lStat != ERROR_SUCCESS)
   {
-    PLOG_ERROR << "Failed to register for registry notifications: " << _init.sub_key << ", " << _init.watch_subtree;
-    RegCloseKey (_hKeyBase);
-    CloseHandle (_hEvent);
-    _hEvent = NULL;
+    PLOG_ERROR << "Failed to register for registry notifications: "
+               << ((_init.root == HKEY_LOCAL_MACHINE)  ? R"(HKLM\)" :
+                   (_init.root == HKEY_CURRENT_USER)   ? R"(HKCU\)" :
+                   (_init.root == HKEY_CLASSES_ROOT)   ? R"(HKCR\)" :
+                   (_init.root == HKEY_USERS)          ? R"(HKU\)" :
+                   (_init.root == HKEY_CURRENT_CONFIG) ? R"(HKEY_CURRENT_CONFIG\)" : "")
+               << _init.sub_key
+               << ", " << _init.watch_subtree
+               << ", " << _init.filter_mask
+               << ", " << _init.wow64_32key
+               << ", " << _init.wow64_32key;
+
+    if (_hKeyBase != NULL)
+    {
+      RegCloseKey (_hKeyBase);
+      _hKeyBase = NULL;
+    }
+
+    if (_hEvent != NULL)
+    {
+      CloseHandle (_hEvent);
+      _hEvent   = NULL;
+    }
   }
 }
 


### PR DESCRIPTION
This adds a new Vulkan Layer Management section to the Hardware tab. It also clarifies the UI used for the Vulkan section on the Monitor tab to reduce user confusion.

It also fixes a bug with SKIF_RegistryWatch that added a duplicate handle to the wait vector which could theoretically cause the app to lock up on its main timeout wait/idle function.

The commits also move the Vulkan layer check over to using a registry watch for refreshes instead of the constant 1-second refreshing that the live code is doing.

*Note that FPS Monitor is only used as an example in the below screens. No known compatibility issues with its layer exists as far as I am aware.*

Hardware tab:
<img width="1000" height="494" alt="image" src="https://github.com/user-attachments/assets/a44df255-d4fd-4665-a2ee-5a7a526be886" />

Monitor tab:
<img width="450" height="265" alt="image" src="https://github.com/user-attachments/assets/1457908b-a5f8-4d4d-88ff-392a9b612d97" />
